### PR TITLE
Añadir año en el calendario del mes

### DIFF
--- a/src/core/components/organisms/calendar/big-calendar.tsx
+++ b/src/core/components/organisms/calendar/big-calendar.tsx
@@ -44,7 +44,7 @@ export const BigCalendar: FC<BigCalendarProps> = ({ events }) => {
       dayFormat: Datetime.toDayString,
       dateFormat: Datetime.toDayNumberString,
       agendaDateFormat: Datetime.toDayString,
-      monthHeaderFormat: Datetime.toMonthString,
+      monthHeaderFormat: Datetime.toMonthYearString,
       weekdayFormat: Datetime.toWeekdayString,
       dayRangeHeaderFormat: (range: { start: Date; end: Date }) =>
         Datetime.toDateRangeString(range.start, range.end),

--- a/src/core/datetime/datetime.ts
+++ b/src/core/datetime/datetime.ts
@@ -63,6 +63,10 @@ export class Datetime {
     return dayjs(date).locale("es").format("MMMM");
   }
 
+  static toMonthYearString(date: Date): string {
+    return dayjs(date).locale("es").format("MMMM YYYY");
+  }
+
   static toWeekdayString(date: Date): string {
     return dayjs(date).locale("es").format("ddd");
   }


### PR DESCRIPTION
## Problema

Estaba usando la aplicación y cuando llegué a ver el calendario de eventos y lo usé, me di cuenta de algo que me confundía.
Cuando el calendario está en **modo mes** y vas pasando por los meses, puedes pasar de año pero no sabes en que año estás ni lo muestra en ningún lado, como se ve en las siguientes imágenes.

![Captura de pantalla 2023-06-01 a las 16 42 18](https://github.com/achamorro-dev/eventoswiki/assets/32195484/5eb8c83e-fc05-4981-9259-2c76d89e8ebe)

![Captura de pantalla 2023-06-01 a las 16 42 27](https://github.com/achamorro-dev/eventoswiki/assets/32195484/a23f65f3-a66a-401c-b974-724adfcdbfc0)

## Solución

He añadido un nuevo método a la clase Datetime que devuelve el mes junto con el año y de esta manera el usuario siempre sabe en que año está.

Espero que sea útil y enhorabuena por el proyecto, me gusta bastante 😃 

<img width="1403" alt="Captura de pantalla 2023-06-01 a las 20 58 23" src="https://github.com/achamorro-dev/eventoswiki/assets/32195484/5f2e8da9-412b-4340-9ddf-47725275d567">

<img width="1403" alt="Captura de pantalla 2023-06-01 a las 20 58 11" src="https://github.com/achamorro-dev/eventoswiki/assets/32195484/9640c700-aa00-4266-9d66-713ce1fa8bd5">