### PR TITLE
Cambiar borde de las cards en modo oscuro

### DIFF
--- a/src/core/components/atoms/card/card.tsx
+++ b/src/core/components/atoms/card/card.tsx
@@ -8,7 +8,7 @@ export const Card: FC<PropsWithChildren<CardProps>> = (props) => {
   const { className = '', children } = props
   return (
     <div
-      className={`flex flex-col items-start col-span-12 overflow-hidden shadow-sm rounded-xl border md:col-span-6 lg:col-span-4 ${className} dark:bg-slate-600`}
+      className={`flex flex-col items-start col-span-12 overflow-hidden shadow-sm rounded-xl border dark:border-slate-800 md:col-span-6 lg:col-span-4 ${className} dark:bg-slate-600`}
     >
       {children}
     </div>


### PR DESCRIPTION
## Sugerencia

En el modo oscuro se ve un borde blanco, a lo mejor era la intención pero te hago una mini propuesta de dejarlo sin el borde blanco y que se vea más limpio visualmente por decirlo de alguna manera.

He puesto el color del borde de las cards en modo oscuro igual al fondo. No lo he quitado porque si no cambiaría el tamaño de las cards al cambiar de modo claro a oscuro. Tampoco he usado en transparente ya que se sigue viendo un borde pequeño.

> Hay otra PR poniendo el borde transparante ya que a lo mejor te gusta más.
> PR borde transparente #36 

### Antes 

![Captura de pantalla 2023-06-02 a las 12 02 33](https://github.com/achamorro-dev/eventoswiki/assets/32195484/c2cd3406-acc2-4446-aa4a-0bb7deda96b0)

### Ahora

![Captura de pantalla 2023-06-02 a las 12 03 02](https://github.com/achamorro-dev/eventoswiki/assets/32195484/0b760bc0-58a2-418a-ba6c-bab2b65c09bd)


