### PR TITLE
Cambiar borde de las cards en modo oscuro a transparente

### DIFF
--- a/src/core/components/atoms/card/card.tsx
+++ b/src/core/components/atoms/card/card.tsx
@@ -8,7 +8,7 @@ export const Card: FC<PropsWithChildren<CardProps>> = (props) => {
   const { className = '', children } = props
   return (
     <div
-      className={`flex flex-col items-start col-span-12 overflow-hidden shadow-sm rounded-xl border dark:border-transparent md:col-span-6 lg:col-span-4 ${className} dark:bg-slate-600`}
+      className={`flex flex-col items-start col-span-12 overflow-hidden shadow-sm rounded-xl border dark:border-white dark:border-opacity-10 md:col-span-6 lg:col-span-4 ${className} dark:bg-slate-600`}
     >
       {children}
     </div>

--- a/src/core/components/atoms/card/card.tsx
+++ b/src/core/components/atoms/card/card.tsx
@@ -8,7 +8,7 @@ export const Card: FC<PropsWithChildren<CardProps>> = (props) => {
   const { className = '', children } = props
   return (
     <div
-      className={`flex flex-col items-start col-span-12 overflow-hidden shadow-sm rounded-xl border md:col-span-6 lg:col-span-4 ${className} dark:bg-slate-600`}
+      className={`flex flex-col items-start col-span-12 overflow-hidden shadow-sm rounded-xl border dark:border-transparent md:col-span-6 lg:col-span-4 ${className} dark:bg-slate-600`}
     >
       {children}
     </div>


### PR DESCRIPTION
En el modo oscuro se ve un borde blanco, a lo mejor era la intención pero te hago una mini propuesta de dejarlo con el borde transparente y que se vea más limpio visualmente por decirlo de alguna manera.

He puesto el borde trasparente en este caso para que se vea un pequeño borde pero más disimulado.

> Hay otra PR poniendo el borde del color del fondo ya que a lo mejor te gusta más.
> PR borde color de fondo #35 

### Antes

![Captura de pantalla 2023-06-02 a las 12 02 33](https://github.com/achamorro-dev/eventoswiki/assets/32195484/4acc19b2-2562-4ae2-adff-2a5f5c6c60e6)

### Después

![Captura de pantalla 2023-06-02 a las 12 06 34](https://github.com/achamorro-dev/eventoswiki/assets/32195484/a3ab5ae1-b8f2-4d26-a7d0-ea3e296a13d1)
