### PR TITLE
Arreglar FOUC al recargar la página cuando el modo oscuro está activado

### DIFF
--- a/src/core/components/base-head.astro
+++ b/src/core/components/base-head.astro
@@ -46,5 +46,16 @@ const {
   <link rel="canonical" href={url} />
   <title>{title}</title>
   <ViewTransitions />
+  <script is:inline>
+    const localStorageValue = localStorage?.getItem('theme-mode')
+    const preferDark = window.matchMedia('(prefers-color-scheme: dark)').matches
+    const darkTheme = 'dark'
+
+    if (preferDark || localStorageValue === darkTheme) {
+      document.documentElement.classList.add(darkTheme)
+    } else {
+      document.documentElement.classList.remove(darkTheme)
+    }
+  </script>
 </head>
 <slot />


### PR DESCRIPTION
Este PR soluciona #52.

El destello de contenido sin estilo (FOUC) es provocado porque al recargar una vista, el JavaScript necesario para detectar la preferencia del usuario u obtener el valor almacenado en localStorage para el dark mode no es obtenido a tiempo.

Con este pequeño script en línea en el head, hace la comprobación para el dark mode y aplica la clase CSS necesaria, por lo que al momento de que el navegador descargue el CSS ya no se produzca el destello.


https://github.com/achamorro-dev/eventoswiki/assets/38303370/76520bff-501c-40dd-aa1d-4547f3b962a3