### PR TITLE
Cambio de tamaño cuando aparece el scroll

### DIFF
--- a/src/layouts/layout.astro
+++ b/src/layouts/layout.astro
@@ -13,7 +13,7 @@ const { title, description } = Astro.props;
 ---
 
 <!doctype html>
-<html lang="es">
+<html lang="es" style="scrollbar-gutter: stable;">
   <BaseHead title={title} description={description} />
   <body
     class="bg-white dark:bg-slate-800 grid min-h-full m-0 grid-rows-[auto_1fr_auto]"


### PR DESCRIPTION
### Problema

Cuando navegas entre páginas y aparece un scrollbar la dimensión cambia y esto hace que se muevan los elementos.
Puede parecer poca cosa pero es algo que se nota mientras usuario navega.

**Video de ejemplo**


https://github.com/achamorro-dev/eventoswiki/assets/32195484/b6cb1017-40ac-48d5-a808-b2447614c501

### Solución

Usando la propiedad de css scrollbar-gutter con el valor stable se arregla esto.

Actualmente no se encuentra esta propiedad en Taildwind así que la puse inline.

**Video Arreglado**

https://github.com/achamorro-dev/eventoswiki/assets/32195484/8c7ac9ed-9ef1-479a-8498-7740c7383b73

