### PR TITLE
Feat: Añadir páginas con eventos por ciudad

### DIFF
--- a/src/core/components/organisms/footer/footer.astro
+++ b/src/core/components/organisms/footer/footer.astro
@@ -22,8 +22,10 @@ const locationsSorted = locationsFiltered.sort((a, b) => a.localeCompare(b))
       <ul class="grid grid-cols-2 lg:grid-cols-3 list-none p-0">
         {
           locationsSorted.map(location => (
-            <li class="m-0 leading-none">
-              <a href={`/eventos/${EventUtils.slugify(location)}/1/`}>{location}</a>
+            <li class="m-0 leading-tight">
+              <a href={`/eventos/${EventUtils.slugify(location)}/1/`} class="hover:text-accent">
+                {location}
+              </a>
             </li>
           ))
         }

--- a/src/core/components/organisms/footer/footer.astro
+++ b/src/core/components/organisms/footer/footer.astro
@@ -16,32 +16,30 @@ const locationsSorted = locationsFiltered.sort((a, b) => a.localeCompare(b))
 ---
 
 <footer class="text-gray-700 bg-white dark:bg-slate-900 body-font border-t border-gray-200 dark:border-transparent">
-  <section class="container flex flex-col justify-between px-8 py-8 mx-auto max-w-7xl sm:flex-row">
-    <div class="w-full mb-6">
-      <h2 class="py-2">Eventos por ciudad</h2>
-      <ul class="grid grid-cols-2 lg:grid-cols-3 list-none p-0">
-        {
-          locationsSorted.map(location => (
-            <li class="m-0">
-              <a href={`/eventos/${EventUtils.slugify(location)}/1`} class="text-sm hover:text-accent">
-                {location}
-              </a>
-            </li>
-          ))
-        }
-      </ul>
-    </div>
-    <div class="text-center md:text-right">
-      <h2 class="py-2">Sponsors</h2>
-      <p class="text-md font-light py-0">¡Gracias por su apoyo!</p>
-      <ul class="list-none flex justify-center mt-8">
-        <li>
-          <a href="https://codely.com" rel="nofollow" target="_blank" class="text-[#1a2233] dark:text-[#3cff64]"
-            ><Codely /></a
-          >
-        </li>
-      </ul>
-    </div>
+  <section class="container mx-auto py-4 text-gray-500 text-center dark:text-white">
+    <h2 class="py-2">Sponsors</h2>
+    <p class="text-md font-light py-0">¡Gracias por su apoyo!</p>
+    <ul class="list-none flex justify-center mt-8">
+      <li>
+        <a href="https://codely.com" rel="nofollow" target="_blank" class="text-[#1a2233] dark:text-[#3cff64]"
+          ><Codely /></a
+        >
+      </li>
+    </ul>
+  </section>
+  <section class="container mx-auto max-w-7xl py-4 text-gray-500 text-center dark:text-white">
+    <h2 class="py-2">Eventos por ciudad</h2>
+    <ul class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-x-2 list-none p-0 mt-2">
+      {
+        locationsSorted.map(location => (
+          <li class="m-0">
+            <a href={`/eventos/${EventUtils.slugify(location)}/1`} class="text-sm hover:text-accent">
+              {location}
+            </a>
+          </li>
+        ))
+      }
+    </ul>
   </section>
   <section class="container flex flex-col items-center px-8 py-8 mx-auto max-w-7xl sm:flex-row">
     <Logo />

--- a/src/core/components/organisms/footer/footer.astro
+++ b/src/core/components/organisms/footer/footer.astro
@@ -22,8 +22,8 @@ const locationsSorted = locationsFiltered.sort((a, b) => a.localeCompare(b))
       <ul class="grid grid-cols-2 lg:grid-cols-3 list-none p-0">
         {
           locationsSorted.map(location => (
-            <li class="m-0 leading-tight">
-              <a href={`/eventos/${EventUtils.slugify(location)}/1/`} class="hover:text-accent">
+            <li class="m-0">
+              <a href={`/eventos/${EventUtils.slugify(location)}/1`} class="text-sm hover:text-accent">
                 {location}
               </a>
             </li>

--- a/src/core/components/organisms/footer/footer.astro
+++ b/src/core/components/organisms/footer/footer.astro
@@ -1,26 +1,45 @@
 ---
+import type { AstroEvent } from '../../../events/astro-event'
+import { EventUtils } from '../../../events/event-utils'
+
 import { Github } from '../../atoms/icons/github'
 import { Twitter } from '../../atoms/icons/twitter'
 import { Logo } from '../../molecules/logo/logo'
 
 import { Codely } from '../../atoms/sponsors/codely'
+
+const events = (await Astro.glob('../../../../pages/eventos/**/*.mdx')) as AstroEvent[]
+
+const locations = EventUtils.getLocationEvents(events)
+const locationsFiltered = locations.filter(location => !location.includes('Online'))
+const locationsSorted = locationsFiltered.sort((a, b) => a.localeCompare(b))
 ---
 
 <footer class="text-gray-700 bg-white dark:bg-slate-900 body-font border-t border-gray-200 dark:border-transparent">
-  <section class="container mx-auto py-4 text-gray-500 text-center dark:text-white">
-    <h2 class="py-2">Sponsors</h2>
-    <p class="text-md font-light py-0">¡Gracias por su apoyo!</p>
-    <ul class="list-none flex justify-center mt-8">
-      <li>
-        <a
-          href="https://codely.com"
-          alt="Codely"
-          rel="nofollow"
-          target="_blank"
-          class="text-[#1a2233] dark:text-[#3cff64]"><Codely /></a
-        >
-      </li>
-    </ul>
+  <section class="container flex flex-col justify-between px-8 py-8 mx-auto max-w-7xl sm:flex-row">
+    <div class="w-full mb-6">
+      <h2 class="py-2">Eventos por ciudad</h2>
+      <ul class="grid grid-cols-2 lg:grid-cols-3 list-none p-0">
+        {
+          locationsSorted.map(location => (
+            <li class="m-0 leading-none">
+              <a href={`/eventos/${EventUtils.slugify(location)}/1/`}>{location}</a>
+            </li>
+          ))
+        }
+      </ul>
+    </div>
+    <div class="text-center md:text-right">
+      <h2 class="py-2">Sponsors</h2>
+      <p class="text-md font-light py-0">¡Gracias por su apoyo!</p>
+      <ul class="list-none flex justify-center mt-8">
+        <li>
+          <a href="https://codely.com" rel="nofollow" target="_blank" class="text-[#1a2233] dark:text-[#3cff64]"
+            ><Codely /></a
+          >
+        </li>
+      </ul>
+    </div>
   </section>
   <section class="container flex flex-col items-center px-8 py-8 mx-auto max-w-7xl sm:flex-row">
     <Logo />
@@ -49,5 +68,4 @@ import { Codely } from '../../atoms/sponsors/codely'
       </a>
     </span>
   </section>
-</footer>
 </footer>

--- a/src/core/components/organisms/last-events/last-events.astro
+++ b/src/core/components/organisms/last-events/last-events.astro
@@ -6,14 +6,20 @@ import { Link } from '../../atoms/link/link'
 import EventsGrid from '../events-grid/events-grid.astro'
 
 const events = (await Astro.glob('../../../../pages/eventos/**/*.mdx')) as AstroEvent[]
-const lastEventsFiltered = EventUtils.getLastEvents(events)
+
+const { location } = Astro.props
+
+const locationName = EventUtils.getLocationName(events, location)
+
+const lastEventsFiltered = EventUtils.getLastEvents(events, { location })
 const lastEvents = EventUtils.sortByStartDateDesc(lastEventsFiltered).slice(0, 6)
 ---
 
 <section class="mt-12">
   <div class="flex items-center justify-between mt-4 mb-10">
-    <GradientTitle>Últimos eventos</GradientTitle>
+    <GradientTitle>Últimos eventos{locationName && ` en ${locationName}`}</GradientTitle>
     <Link href="/eventos/archivados/1" className="text-right">Ver más</Link>
   </div>
+  {lastEvents.length === 0 && <p class="opacity-50">Aún no hay información sobre eventos pasados</p>}
   <EventsGrid events={lastEvents} />
 </section>

--- a/src/core/components/organisms/next-events/next-events.astro
+++ b/src/core/components/organisms/next-events/next-events.astro
@@ -7,14 +7,19 @@ import EventsGrid from '../events-grid/events-grid.astro'
 
 const events = (await Astro.glob('../../../../pages/eventos/**/*.mdx')) as AstroEvent[]
 
-const nextEventsFiltered = EventUtils.getNextEvents(events)
+const { location } = Astro.props
+
+const locationName = EventUtils.getLocationName(events, location)
+
+const nextEventsFiltered = EventUtils.getNextEvents(events, { location })
 const nextEvents = EventUtils.sortByStartDateAsc(nextEventsFiltered).slice(0, 6)
 ---
 
 <section>
   <div class="flex items-center justify-between mt-4 mb-10">
-    <GradientTitle>Próximos eventos</GradientTitle>
+    <GradientTitle>Próximos eventos{locationName && ` en ${locationName}`}</GradientTitle>
     <Link href="/eventos/1" className="text-right">Ver más</Link>
   </div>
+  {nextEvents.length === 0 && <p class="opacity-50">Aún no hay información sobre próximos eventos</p>}
   <EventsGrid events={nextEvents} />
 </section>

--- a/src/core/events/astro-event.ts
+++ b/src/core/events/astro-event.ts
@@ -4,3 +4,7 @@ export interface AstroEvent {
   frontmatter: Event
   url: string
 }
+
+export type FilterEvent = {
+  location?: string;
+}

--- a/src/core/events/event-utils.ts
+++ b/src/core/events/event-utils.ts
@@ -33,9 +33,9 @@ export class EventUtils {
     return [...new Set(locations)];
   }
 
-  static getLocationName(events: AstroEvent[], slug: string): string {
+  static getLocationName(events: AstroEvent[], location: string): string {
     return events
-      .find((event) => this.slugify(event.frontmatter.location) === slug)
+      .find((event) => this.slugify(event.frontmatter.location) === location)
       ?.frontmatter.location ?? '';
   }
 

--- a/src/core/events/event-utils.ts
+++ b/src/core/events/event-utils.ts
@@ -1,21 +1,42 @@
 import { Datetime } from "../datetime/datetime";
-import type { AstroEvent } from "./astro-event";
+import type { AstroEvent, FilterEvent } from "./astro-event";
 
 export class EventUtils {
-  static getNextEvents(events: AstroEvent[]): AstroEvent[] {
+  static getNextEvents(events: AstroEvent[], filter?: FilterEvent): AstroEvent[] {
     return events.filter((event) => {
       if (!event.frontmatter.endDate) return false;
+
+      if (filter && filter.location) {
+        if (this.slugify(event.frontmatter.location) !== filter.location) return false;
+      }
 
       return Datetime.isAfterYesterday(event.frontmatter.endDate);
     });
   }
 
-  static getLastEvents(events: AstroEvent[]): AstroEvent[] {
+  static getLastEvents(events: AstroEvent[], filter?: FilterEvent): AstroEvent[] {
     return events.filter((event) => {
       if (!event.frontmatter.endDate) return false;
 
+      if (filter && filter.location) {
+        if (this.slugify(event.frontmatter.location) !== filter.location) return false;
+      }
+
       return Datetime.isBeforeToday(event.frontmatter.endDate);
     });
+  }
+
+  static getLocationEvents(events: AstroEvent[]): string[] {
+    const locations = events
+      .map((event) => event.frontmatter.location ?? '')
+      .filter((location) => location !== '');
+    return [...new Set(locations)];
+  }
+
+  static getLocationName(events: AstroEvent[], slug: string): string {
+    return events
+      .find((event) => this.slugify(event.frontmatter.location) === slug)
+      ?.frontmatter.location ?? '';
   }
 
   static sortByStartDateAsc(events: AstroEvent[]): AstroEvent[] {
@@ -34,5 +55,21 @@ export class EventUtils {
         eventB.frontmatter.startDate
       );
     });
+  }
+
+  static slugify(text?: string): string {
+    if (!text) return "";
+    return text
+      .toString()
+      .toLowerCase()
+      .normalize("NFD")
+      .trim()
+      .replace(/[\u0300-\u036f]/g, "")
+      .replace(/\s+/g, "-")
+      .replace(/&/g, "-and-")
+      .replace(/[^\w-]+/g, "")
+      .replace(/--+/g, "-")
+      .replace(/^-+/, "")
+      .replace(/-+$/, "");
   }
 }

--- a/src/pages/eventos/2022/agile-real-life.mdx
+++ b/src/pages/eventos/2022/agile-real-life.mdx
@@ -6,7 +6,7 @@ startDate: '2022-10-15T07:30:00.000Z'
 endDate: '2022-10-15T13:00:00.000Z'
 thumbnail: 'https://info.paradigmadigital.com/hubfs/Paradigma_Nueva_Marca/imagenes/agileday_header.jpg'
 image: 'https://info.paradigmadigital.com/hubfs/Paradigma_Nueva_Marca/imagenes/agileday_header.jpg'
-location: 'Madrid [Paradigma Digital]'
+location: 'Madrid'
 web: https://eventos.paradigmadigital.com/agile-real-life-2022
 twitter: https://twitter.com/paradigmate
 instagram: https://www.instagram.com/paradigma_digital/

--- a/src/pages/eventos/2022/api-addicts-days.mdx
+++ b/src/pages/eventos/2022/api-addicts-days.mdx
@@ -6,7 +6,7 @@ startDate: '2022-10-06T07:00:00.000Z'
 endDate: '2022-10-06T17:00:00.000Z'
 thumbnail: 'https://www.apiaddicts.org/wp-content/uploads/2022/09/APIAddictsDays22-6.png'
 image: 'https://www.apiaddicts.org/wp-content/uploads/2022/09/APIAddictsDays22-6.png'
-location: 'Online y Madrid [La Nave]'
+location: 'Madrid'
 web: https://www.apiaddicts.org/apiaddictsdays22/
 twitter: https://twitter.com/apiaddicts
 youtube: https://www.youtube.com/channel/UCepaRmZBCmbdU4QqNhSV5jQ

--- a/src/pages/eventos/2022/cas-agile-spain.mdx
+++ b/src/pages/eventos/2022/cas-agile-spain.mdx
@@ -6,7 +6,7 @@ startDate: '2022-11-10T08:00:00.000Z'
 endDate: '2022-11-11T18:00:00.000Z'
 thumbnail: 'https://cas2022.agile-spain.org/wp-content/uploads/2022/07/cropped-CAS_FINALES-95-Angel-de-la-igesia.jpg'
 image: 'https://cas2022.agile-spain.org/wp-content/uploads/2022/07/cropped-CAS_FINALES-95-Angel-de-la-igesia.jpg'
-location: 'Palexco, A Coruña'
+location: 'A Coruña'
 web: https://cas2022.agile-spain.org/
 twitter: https://twitter.com/agilespain
 linkedin: https://www.linkedin.com/in/agile-spain/

--- a/src/pages/eventos/2022/codemotion-spain.mdx
+++ b/src/pages/eventos/2022/codemotion-spain.mdx
@@ -6,7 +6,7 @@ startDate: '2022-11-22T10:00:00.000Z'
 endDate: '2022-11-23T18:00:00.000Z'
 thumbnail: 'https://i.ibb.co/1TqTjDR/Preview-Events-online-conf-spa.png'
 image: 'https://i.ibb.co/1TqTjDR/Preview-Events-online-conf-spa.png'
-location: 'Online + Madrid'
+location: 'Madrid'
 web: https://events.codemotion.com/conferences/online/2022/online-tech-conference-2022-spanish-edition-autumn#home
 twitter: https://twitter.com/CodemoMadrid
 tags: [general, devs]

--- a/src/pages/eventos/2022/contratar-y-gestionar-diseñadores-sin-ser-diseñador.mdx
+++ b/src/pages/eventos/2022/contratar-y-gestionar-diseñadores-sin-ser-diseñador.mdx
@@ -6,7 +6,7 @@ startDate: '2022-09-29T16:30:00.000Z'
 endDate: '2022-09-29T18:30:00.000Z'
 thumbnail: 'https://img.evbuc.com/https%3A%2F%2Fcdn.evbuc.com%2Fimages%2F355655529%2F291704233486%2F1%2Foriginal.20220916-104356?w=940&auto=format%2Ccompress&q=75&sharp=10&rect=0%2C127%2C2114%2C1057&s=e7b35d9b1e4669bebd23fd089cb07a10'
 image: 'https://img.evbuc.com/https%3A%2F%2Fcdn.evbuc.com%2Fimages%2F355655529%2F291704233486%2F1%2Foriginal.20220916-104356?w=940&auto=format%2Ccompress&q=75&sharp=10&rect=0%2C127%2C2114%2C1057&s=e7b35d9b1e4669bebd23fd089cb07a10'
-location: 'A Coruña [Corunet/Sngular]'
+location: 'A Coruña'
 web: https://www.eventbrite.es/e/entradas-contratar-y-gestionar-disenadores-sin-ser-disenador-420759762777
 twitter: https://twitter.com/startupgalicia
 tags: [general, diseño]

--- a/src/pages/eventos/2022/kudos-openspace.mdx
+++ b/src/pages/eventos/2022/kudos-openspace.mdx
@@ -6,7 +6,7 @@ startDate: '2022-09-17T08:00:00.000Z'
 endDate: '2022-09-17T18:00:00.000Z'
 thumbnail: 'https://openkudos.es/static/media/hero1.d3d1f4e779be8a046f05.avif'
 image: 'https://openkudos.es/static/media/hero1.d3d1f4e779be8a046f05.avif'
-location: 'Madrid [Madhat]'
+location: 'Madrid'
 web: https://openkudos.es/
 twitter: https://twitter.com/openKudos
 tags: [open space, devs, design, ai]

--- a/src/pages/eventos/2022/tarugo.mdx
+++ b/src/pages/eventos/2022/tarugo.mdx
@@ -6,7 +6,7 @@ startDate: '2022-10-20T09:00:00.000Z'
 endDate: '2022-10-22T16:00:00.000Z'
 thumbnail: 'https://www.tarugoconf.com/img/poster-promo22.jpg'
 image: 'https://www.tarugoconf.com/img/poster-promo22.jpg'
-location: 'Madrid [La Nave]'
+location: 'Madrid'
 web: https://www.tarugoconf.com/
 twitter: https://twitter.com/tarugoconf
 tags: [general, open space]

--- a/src/pages/eventos/2022/the-anti-event.mdx
+++ b/src/pages/eventos/2022/the-anti-event.mdx
@@ -6,7 +6,7 @@ startDate: '2022-10-07T14:00:00.000Z'
 endDate: '2022-10-08T18:00:00.000Z'
 thumbnail: 'https://theantievent.org/assets/img/hero.jpg'
 image: 'https://theantievent.org/assets/img/hero.jpg'
-location: 'Bizkaia, Bilbao'
+location: 'Bilbao'
 web: https://theantievent.org/index-es.html
 twitter: https://twitter.com/TheAntiEvent
 tags: [devs, open space]

--- a/src/pages/eventos/2022/wtm-zaragoza.mdx
+++ b/src/pages/eventos/2022/wtm-zaragoza.mdx
@@ -6,7 +6,7 @@ startDate: '2022-11-12T08:30:00.000Z'
 endDate: '2022-11-12T14:45:00.000Z'
 thumbnail: 'https://wtmz22.mullerestech.es/img/portada/home.jpg'
 image: 'https://wtmz22.mullerestech.es/img/portada/home.jpg'
-location: 'Zaragoza [Centro de Arte y Tecnología]'
+location: 'Zaragoza'
 web: https://wtmz22.mullerestech.es/
 twitter: https://twitter.com/WTMZaragoza
 github: https://github.com/MulleresTechZgz

--- a/src/pages/eventos/2023/jornadas-sig-libre.mdx
+++ b/src/pages/eventos/2023/jornadas-sig-libre.mdx
@@ -6,7 +6,7 @@ startDate: '2023-06-14T07:45:00.000Z'
 endDate: '2023-06-15T13:00:00.000Z'
 thumbnail: 'https://res.cloudinary.com/djknud5lr/image/upload/c_scale,w_1500/v1686286747/jornadas_sig_libre_2023_xcha6i.webp'
 image: 'https://res.cloudinary.com/djknud5lr/image/upload/c_scale,w_1500/v1686286747/jornadas_sig_libre_2023_xcha6i.webp'
-location: 'Girona [Universitat de Girona]'
+location: 'Girona'
 web: https://www.jornadassiglibre.org/
 twitter: https://twitter.com/siglibregirona
 youtube: https://www.youtube.com/channel/UCRJxIASneZaMxT2HPoyMLsA

--- a/src/pages/eventos/2023/pamplona-software-crafters.mdx
+++ b/src/pages/eventos/2023/pamplona-software-crafters.mdx
@@ -6,7 +6,7 @@ startDate: '2023-06-02T08:00:00.000Z'
 endDate: '2023-06-03T17:00:00.000Z'
 thumbnail: 'https://pamplonaswcraft.com/assets/images/scpna-1.jpg'
 image: 'https://pamplonaswcraft.com/assets/images/scpna-1.jpg'
-location: Pamplona, Navarra
+location: Pamplona
 web: https://pamplonaswcraft.com/
 twitter: https://twitter.com/pamplonaswcraft
 tags: [general]

--- a/src/pages/eventos/2023/pycones.mdx
+++ b/src/pages/eventos/2023/pycones.mdx
@@ -6,7 +6,7 @@ startDate: '2023-10-06T10:00:00.000Z'
 endDate: '2023-10-08T16:30:00.000Z'
 thumbnail: 'https://github.com/achamorro-dev/eventoswiki/assets/1591599/1a149911-d5f2-4e54-8956-82bcfc8ebb8d'
 image: 'https://github.com/achamorro-dev/eventoswiki/assets/1591599/1a149911-d5f2-4e54-8956-82bcfc8ebb8d'
-location: 'Tenerife [Aulario de Guajara]'
+location: 'Tenerife'
 web: https://2023.es.pycon.org/
 twitter: https://twitter.com/pycones
 youtube: https://www.youtube.com/PythonEspa%C3%B1aOficial

--- a/src/pages/eventos/2023/socrates-canaries.mdx
+++ b/src/pages/eventos/2023/socrates-canaries.mdx
@@ -6,7 +6,7 @@ startDate: '2023-05-11T14:00:00.000Z'
 endDate: '2023-05-14T10:00:00.000Z'
 thumbnail: 'https://static.wixstatic.com/media/98c96b_e3b4e07f42e34fc2b812a5980e8fc4a1~mv2.jpg/v1/fill/w_2500,h_1666,al_c/98c96b_e3b4e07f42e34fc2b812a5980e8fc4a1~mv2.jpg'
 image: 'https://user-images.githubusercontent.com/76959039/195334509-6cf85837-e148-4973-8513-2752414e4980.png'
-location: 'Tenerife [Hotel Escuela Santa Cruz]'
+location: 'Tenerife'
 web: https://www.socracan.com/
 twitter: https://twitter.com/socracan
 tags: [general, devs]

--- a/src/pages/eventos/2023/t3chfest.mdx
+++ b/src/pages/eventos/2023/t3chfest.mdx
@@ -6,7 +6,7 @@ startDate: '2023-03-02T08:00:00.000Z'
 endDate: '2023-03-03T18:00:00.000Z'
 thumbnail: 'https://t3chfest.es/2023/media/social/t3f.png'
 image: 'https://t3chfest.es/2023/media/social/t3f.png'
-location: 'Madrid [Universidad Carlos III]'
+location: 'Madrid'
 web: https://t3chfest.es/2023/
 twitter: https://twitter.com/t3chfest
 youtube: https://www.youtube.com/user/t3chFest

--- a/src/pages/eventos/2023/trgcon.mdx
+++ b/src/pages/eventos/2023/trgcon.mdx
@@ -6,7 +6,7 @@ startDate: '2023-10-26T13:30:00.000Z'
 endDate: '2023-10-28T16:00:00.000Z'
 thumbnail: 'https://res.cloudinary.com/djknud5lr/image/upload/v1687238443/trgcon_23_yguzr0.webp'
 image: 'https://res.cloudinary.com/djknud5lr/image/upload/v1687238443/trgcon_23_yguzr0.webp'
-location: 'Madrid [La Nave]'
+location: 'Madrid'
 web: https://www.trgcon.com/
 twitter: https://twitter.com/tarugoconf
 tags: [general, open space]

--- a/src/pages/eventos/2024/bilbostack.mdx
+++ b/src/pages/eventos/2024/bilbostack.mdx
@@ -6,7 +6,7 @@ startDate: '2024-01-27T08:00:00.000Z'
 endDate: '2024-01-27T13:00:00.000Z'
 thumbnail: 'https://bilbostack.com/bg.jpg'
 image: 'https://bilbostack.com/bg.jpg'
-location: 'Bilbao [Palacio Euskalduna Jauregia]'
+location: 'Bilbao'
 web: https://bilbostack.com/
 twitter: https://twitter.com/BilboStack
 tags: [general]

--- a/src/pages/eventos/2024/trgcon.mdx
+++ b/src/pages/eventos/2024/trgcon.mdx
@@ -6,7 +6,7 @@ startDate: '2024-11-14T13:30:00.000Z'
 endDate: '2024-11-16T16:00:00.000Z'
 thumbnail: 'https://res.cloudinary.com/djknud5lr/image/upload/v1705386640/trgcon_cmbcmi.webp'
 image: 'https://res.cloudinary.com/djknud5lr/image/upload/v1705386640/trgcon_cmbcmi.webp'
-location: 'Madrid [La Nave]'
+location: 'Madrid'
 web: https://www.trgcon.com/
 twitter: https://twitter.com/tarugoconf
 tags: [general, open space]

--- a/src/pages/eventos/[location]/[page].astro
+++ b/src/pages/eventos/[location]/[page].astro
@@ -1,0 +1,18 @@
+---
+import Layout from '../../../layouts/layout.astro'
+import NextEvents from '../../../core/components/organisms/next-events/next-events.astro'
+import LastEvents from '../../../core/components/organisms/last-events/last-events.astro'
+import { EventUtils } from '../../../core/events/event-utils'
+import { AstroEvent } from '../../../core/events/astro-event'
+
+const events = (await Astro.glob('../**/*.mdx')) as AstroEvent[]
+
+const { location = '' } = Astro.params
+
+const locationName = EventUtils.getLocationName(events, location)
+---
+
+<Layout title={`eventos.wiki - Eventos en ${locationName}`}>
+  <NextEvents location={location} />
+  <LastEvents location={location} />
+</Layout>


### PR DESCRIPTION
## Mejoras

- [x] Creación de páginas con eventos filtradas por localización.
- [x] Unificación de información de localizaciones.
- [x] Añadidos enlaces en footer.

## Motivos

Permite acceder rápidamente a la información de una ciudad.
Sienta las bases para filtrar por tags, comentado en  #1 
Aumenta las páginas que se indexarán en buscadores.

## Capturas

![image](https://github.com/achamorro-dev/eventoswiki/assets/4882454/8e6aff3d-583e-44a7-bb01-738db637728c)

![image](https://github.com/achamorro-dev/eventoswiki/assets/4882454/12619229-262d-44f0-8306-dc0aa7b1a8a7)
