### PR TITLE
Fix: Control de errores en imagen

### DIFF
--- a/src/core/components/molecules/event-card/event-card.astro
+++ b/src/core/components/molecules/event-card/event-card.astro
@@ -30,7 +30,13 @@ const {
 
 <a href={event.url} class={classes}>
   <Card className="relative transition-shadow duration-300 lg:hover:shadow-md">
-    <img class="object-cover w-full h-56" src={image} alt={altImage || `Foto de portada del evento ${title}`} />
+    <img
+      class="object-cover w-full h-56"
+      src={image}
+      alt={altImage || `Foto de portada del evento ${title}`}
+      loading="lazy"
+      onerror="this.src='/not-found.jpg'"
+    />
     <div class="relative top-0 left-3 -mt-3 flex items-center flex-wrap gap-1 rounded-full">
       {tags.map(t => <Tag color={tagColor}>{t}</Tag>)}
     </div>

--- a/src/layouts/event-layout.astro
+++ b/src/layouts/event-layout.astro
@@ -52,6 +52,8 @@ const {
         src={image}
         alt={altImage || `Foto de portada del evento ${title}`}
         class="absolute w-full h-full object-cover shadow-md bg-white"
+        loading="lazy"
+        onerror="this.src='/not-found.jpg'"
       />
       <div class="absolute w-full h-52 bottom-0 bg-gradient-to-t from-black"></div>
       <div class="absolute w-full bottom-0 px-6 py-4 max-w-5xl left-0 right-0 ml-auto mr-auto xl:px-0">
@@ -192,14 +194,7 @@ const {
 
       .event-container a {
         @apply underline;
-     }
+      }
     </style>
-    <script is:inline>
-      const eventImage = document.getElementById('event-image')
-
-      eventImage.addEventListener('error', function (event) {
-        eventImage.src = '/not-found.jpg'
-      })
-    </script>
   </body>
 </html>

--- a/src/layouts/layout.astro
+++ b/src/layouts/layout.astro
@@ -23,14 +23,5 @@ const { title, description } = Astro.props
       </Container>
     </main>
     <Footer />
-    <script is:inline>
-      const images = document.querySelectorAll('img')
-
-      images.forEach(image => {
-        image.addEventListener('error', function (event) {
-          event.currentTarget.src = '/not-found.jpg'
-        })
-      })
-    </script>
   </body>
 </html>


### PR DESCRIPTION
En la primera carga, no se ejecutaba el script que recorría las imágenes. Se podría haber arreglado con `defer`. En cambio, he pasado ese control a nivel de imagen con `onerror`, para que cada imagen sea responsable de su carga.

![image](https://github.com/achamorro-dev/eventoswiki/assets/4882454/13046ccd-4d8e-40ca-b825-2c14f7d2e8d8)
![image](https://github.com/achamorro-dev/eventoswiki/assets/4882454/5fd729bc-7d80-4cbe-a6e4-c22ee9bf417a)

¡Ah! Y he añadido el `loading=lazy` para evitar cargarlas si no aparecen en pantalla😉 

¡Un saludo!