### PR TITLE
Update OpenExpo Europe 2024 date to June 13

### DIFF
--- a/src/pages/eventos/2024/open-expo-europe.mdx
+++ b/src/pages/eventos/2024/open-expo-europe.mdx
@@ -2,8 +2,8 @@
 layout: ../../../layouts/event-layout.astro
 title: OpenExpo Europe
 shortDescription: OpenExpo Europe lleva una década siendo una de las ventanas de divulgación en Innovación Tecnológica, Transformación Digital y Open Source.
-startDate: '2024-05-09T07:00:00.000Z'
-endDate: '2024-05-09T16:00:00.000Z'
+startDate: '2024-06-13T07:00:00.000Z'
+endDate: '2024-06-13T16:00:00.000Z'
 thumbnail: 'https://openexpoeurope.com/wp-content/uploads/2023/12/OE2024-Slider-Home-V2-scaled.jpg'
 image: 'https://openexpoeurope.com/wp-content/uploads/2023/12/OE2024-Slider-Home-V2-scaled.jpg'
 location: 'Madrid'


### PR DESCRIPTION
Updates the OpenExpo Europe event date for 2024 in the `open-expo-europe.mdx` file.
- Changes the `startDate` and `endDate` to June 13, 2024, to reflect the new event date.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/achamorro-dev/eventoswiki?shareId=d83d1742-ebf9-4047-9c33-0d3f18ee8625).