### PR TITLE
fix: scrollbar over texts

### DIFF
--- a/src/modules/shared/presentation/ui/components/slider/slider.astro
+++ b/src/modules/shared/presentation/ui/components/slider/slider.astro
@@ -12,6 +12,6 @@ const { classes, ...rest } = Astro.props
 
 <style>
   .slider {
-    @apply flex snap-x gap-4 overflow-x-scroll;
+    @apply flex snap-x gap-4 overflow-x-scroll pb-5;
   }
 </style>


### PR DESCRIPTION
# Problema

Cuando haces scroll se ve la barra por encima de los textos.

<img width="1104" alt="image" src="https://github.com/user-attachments/assets/12d828f6-356c-4f32-9402-12cca513954f">

<img width="440" alt="image" src="https://github.com/user-attachments/assets/4bcd27bc-a1f6-4562-954e-179c47fdd734">


# Solución

Añadir un pequeño padding al slider para que no solape con el texto

<img width="1104" alt="image" src="https://github.com/user-attachments/assets/afde7d55-239e-4497-8995-dabfec8c4167">

<img width="440" alt="image" src="https://github.com/user-attachments/assets/8347bdff-9081-440e-a550-322e984f24c4">
