### PR TITLE
fix: update background colors for better visibility

### DIFF
--- a/src/modules/shared/presentation/ui/components/calendar/big-calendar.css
+++ b/src/modules/shared/presentation/ui/components/calendar/big-calendar.css
@@ -62,11 +62,11 @@
 }
 
 .rbc-off-range-bg {
-  @apply dark:bg-primary-dark;
+  @apply dark:bg-background-dark-light;
 }
 
 .rbc-today {
-  @apply bg-primary bg-opacity-50;
+  @apply !bg-primary !bg-opacity-50;
 }
 
 .rbc-btn-group .rbc-active,

--- a/src/modules/shared/presentation/ui/components/calendar/big-calendar.css
+++ b/src/modules/shared/presentation/ui/components/calendar/big-calendar.css
@@ -66,7 +66,7 @@
 }
 
 .rbc-today {
-  @apply !bg-primary !bg-opacity-50;
+  @apply bg-primary bg-opacity-50;
 }
 
 .rbc-btn-group .rbc-active,


### PR DESCRIPTION
¡Hola Alberto!

Revisando el calendario, con tema oscuro, me resulta confuso que los días que no pertenecen al mes actual estén más destacados en color primario. Propongo usar el color existente `bg-background-dark-light`. Así quedaría el preview:

| Antes | Después |
| - | - |
| ![image](https://github.com/user-attachments/assets/b888b770-cc7b-4ade-bc9c-913170c90444) | ![image](https://github.com/user-attachments/assets/0e25d308-db5d-4a0c-83a8-b48783b59a04) |

Espero que sirva.
¡Saludos!