### PR TITLE
feat(events): add JSConf España 2026 event details and schedule

### DIFF
--- a/src/old-content/data/eventos/2026/jsconf-espana.mdx
+++ b/src/old-content/data/eventos/2026/jsconf-espana.mdx
@@ -1,0 +1,50 @@
+---
+layout: ../../../layouts/event-layout.astro
+title: JSConf España 2026
+shortDescription: ¡La JSConf España 2026 aterriza de nuevo en Madrid! El evento de JavaScript más esperado con ponentes internacionales, talleres y la mejor comunidad.
+startDate: '2026-03-14T09:00:00.000Z'
+endDate: '2026-03-14T19:00:00.000Z'
+thumbnail: 'https://www.jsconf.es/og.jpg'
+image: 'https://www.jsconf.es/og.jpg'
+location: 'madrid'
+web: https://www.jsconf.es/
+twitter: https://twitter.com/jsconfes
+tags: [javascript, frontend, devs]
+tagColor: '#f7df1e'
+---
+
+## JSConf España 2026
+
+¡La JSConf España vuelve en 2026 y promete ser más grande que nunca! 
+
+Tras el éxito de la edición de 2025, nos volvemos a reunir en **La Nave, Madrid**, para una jornada intensiva dedicada al ecosistema JavaScript.
+
+### Ponentes ya confirmados
+
+- **Javier Velasco**: Séptimo desarrollador de Vercel y pieza clave en el desarrollo de Next.js.
+- **Gisela Torres**: Blackbelt en Microsoft, experta en Cloud Computing, DevOps y AI.
+- **Carmen Ansio**: Maga de CSS, la que lleva las animaciones al siguiente nivel.
+- **Erick Wendel**: El mayor creador de contenido de Brasil. Habla tan bien Español como Node.js.
+
+### Actividades
+
+- **Charlas**: Un track de contenido con los mejores expertos del mundo.
+- **Talleres**: Sesiones prácticas para profundizar en las últimas tecnologías.
+- **Code Run**: El 13 de marzo, carrera de 8 km por el Retiro para calentar motores.
+- **Networking**: Espacios dedicados para conectar con otros desarrolladores y empresas del sector.
+
+### Localización
+
+El evento tendrá lugar en **La Nave**, el centro de innovación de referencia en Madrid.
+
+Dirección: La Nave, C. Cifuentes, 5, Villaverde, 28021 Madrid
+
+<iframe
+  style="width: 100%; height: 400px;"
+  height="400"
+  allowfullscreen=""
+  loading="lazy"
+  referrerpolicy="no-referrer-when-downgrade"
+  src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d6081.526521926016!2d-3.695997100000001!3d40.3475974!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0xd4226dc6a64c46b%3A0x23e1b239d4aea935!2sLa%20Nave!5e0!3m2!1ses!2ses!4v1726205701374!5m2!1ses!2ses"
+  aria-label="La Nave, C. Cifuentes, 5, Villaverde, 28021 Madrid"
+></iframe>


### PR DESCRIPTION
Añadir JSConf 2026. Creo que ya no es la forma correcta de añadir eventos pero al menos para que tengáis toda la información. Cualquier cosa que necesitéis, me comentáis.